### PR TITLE
Fix broken search image on posts

### DIFF
--- a/_layouts/newpost.html
+++ b/_layouts/newpost.html
@@ -82,7 +82,7 @@
         <form action="http://www.basho.com/search.php" method="get">
           <div class="search">
             <input type="text" name="q" />
-            <input type="image" src="http://www.basho.com/images/btn_search.png" />
+            <input type="image" src="http://s.basho.com/images/btn_search.png" />
           </div>
         </form>
       </header>


### PR DESCRIPTION
The little search image is broken on individual posts, it's referencing a different URL
than the homepage layout is.

See http://recap.basho.com vs
http://recap.basho.com/2012/01/06/Riak-Recap-for-January-4-5
