### PR TITLE
Use Markdown to make email -> blog conversion easy

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,8 @@
 
-markdown: rdiscount
+markdown: redcarpet
 pygments: true
 paginate: 8
 permalink: /:year/:month/:day/:title
 
+redcarpet:
+  extensions: [autolink]

--- a/_posts/2013-02-12-Riak-Recap-for-Jan-29-Feb-10.md
+++ b/_posts/2013-02-12-Riak-Recap-for-Jan-29-Feb-10.md
@@ -1,0 +1,110 @@
+---
+title: Riak Recap for January 29 - February 10
+layout: newpost
+summary:
+---
+
+Evening, Morning, Afternoon to All -
+
+Long overdue Recap coming your way. Code, blogs, meetups, and more.
+
+Heres another reminder about RICON | EAST happening this May in New
+York City. I would love to see all of you there. Also, Basho is paying
+travel and hotel expenses for all speakers, so I expect everyone to
+submit a CFP about their Riak clusters.
+
+* Details here ---> http://ricon.io/east.html
+
+Enjoy, and thanks for being a part of Riak.
+
+Mark
+
+http://twitter.com/pharkmillups
+
+Riak Recap for January 29 - February 10
+==============================
+
+1) Basho hacker Chris Meiklejohn is giving a Riak talk in Providence,
+Rhode Island at Prov Ops on February 25th.
+
+* Details here ---> http://www.meetup.com/provops/events/101785102/
+
+2) Emily Rose is working on some Node.js code called riak-bot that
+handles node configuration, discovery & auto clustering.
+
+* On NPM here ---> https://npmjs.org/package/riak-bot
+
+3) There are Seven Riak meetups happening this Wednesday in the US.
+
+* Details here ---> http://basho.com/seven-riak-meetups-happening-february-13th/
+
+4) Xing is hosting a Riak Meetup On February 20th in Hamburg to talk
+about what they are building with Riak.
+
+* Register here ---> http://www.meetup.com/Riak-Hamburg/events/102504802/
+* And/or here ---> https://www.xing.com/events/riak-meetup-hamburg-1199460
+
+5) Sean Cribbs, Evan Vigil-McClanahan, and a few others pushed out
+v1.5.2 of the Python Client.
+
+* Announcement here --->
+http://lists.basho.com/pipermail/riak-users_lists.basho.com/2013-February/010911.html
+
+6) Michael van Rooijen's Backup gem has Riak support.
+
+* Code here ---> https://github.com/meskyanichi/backup
+
+7) Florian Ragwitz released version 1.4 of his Perl Client.
+
+* Code here ---> https://metacpan.org/release/FLORA/Data-Riak-1.4/
+
+8) InfoQ wrote a short piece on the Riak 1.3rc
+
+* Read here ---> http://www.infoq.com/news/2013/02/riak-1-3-rc
+
+9) Deepak shared this blog post on the list but for those of you who
+just read the Recaps...
+
+* Deploying Riak on EC2 --->
+http://deepakbala.me/2013/02/08/deploying-riak-on-ec2/
+
+10) Kenji Rikitake joined the Basho Engineering Team.
+
+* Short blog about it here --->
+http://basho.com/dr-kenji-rikitake-it-and-computer-security-expert-joins-basho/
+
+11) A few Riak-related gists that came across my radar..
+
+* Installing Riak 1.2.1 on OS X Mountain Lion with Erlang R15B01 --->
+https://gist.github.com/wunki/4722411
+* Working with Riak Dev Instances ---> https://gist.github.com/mrnugget/4721131
+
+12) Basho Hacker Bryce Kerley is working on something called pingapp,
+"A Riak Core Learning Experiece."
+
+* Code here ---> https://github.com/bkerley/riak-core-ping
+
+13) Carl Hall wrote a blog post about using Erlang MapReduce via the
+Ruby client.
+
+* Read here --->
+http://thecarlhall.wordpress.com/2013/02/10/erlang-mapreduce-job-in-riak-using-a-ruby-client/
+
+14) Nathan Evans wrote up a quick post on an error he saw with Riak on startup.
+
+* Read here --->
+http://nbevans.wordpress.com/2013/02/06/riak-timing-out-during-startup/
+
+15) Tom Santero was hacking on something called "pregerl" this weekend
+at Erlang DC, a pregel implementation in Erlang using riak_core.
+
+* Code here ---> https://github.com/pregerl/pregerl
+
+16) Various Q and A
+
+* ---> http://stackoverflow.com/questions/14581106/graceful-riak-force-replace
+* ---> http://stackoverflow.com/questions/14700112/how-do-i-index-already-existing-objects-in-riak
+* ---> http://stackoverflow.com/questions/14719166/riak-java-client-annotation-not-recognized-in-scala-case-class
+* ---> http://stackoverflow.com/questions/14639600/creating-riak-nodes-bitcask-version-clash
+* ---> http://stackoverflow.com/questions/14648204/is-there-any-way-to-provide-authentication-for-riak-database
+* ---> https://ask.fedoraproject.org/question/3712/fedora-18-problem-starting-riak

--- a/_posts/2013-02-26-Riak-Recap-for-Feb-11-26.md
+++ b/_posts/2013-02-26-Riak-Recap-for-Feb-11-26.md
@@ -1,0 +1,127 @@
+---
+title: Riak Recap for February 11 - 26
+layout: newpost
+summary:
+---
+
+Greetings and salutations.
+
+We're now making the Riak recap a team effort for the Basho technical
+evangelists, so expect to see a little more content. This latest is
+particularly long due to the release of 1.3 and a two week gap since
+our last note.
+
+John
+
+http://twitter.com/macintux
+
+## Riak 1.3 was released!
+
+* Basho's announcement ---> http://basho.com/introducing-riak-1-3/
+* GigaOM's coverage ---> http://gigaom.com/2013/02/21/basho-technologies-takes-aim-at-more-enterprises-with-upgrades/
+* The Register's coverage ---> http://www.theregister.co.uk/2013/02/23/basho_gives_riak_greater_data_reliability/
+
+Chris Tilt describes the new multi-datacenter replication in 1.3 with Riak Enterprise
+
+* ---> http://basho.com/advanced-mode-now-available-for-riak-enterprises-multi-datacenter-replication/
+
+Joseph Blomstedt expands on The Register's description of the new Active Anti-Entropy (AAE) functionality
+
+* ---> http://forums.theregister.co.uk/forum/1/2013/02/23/basho_gives_riak_greater_data_reliability/#c_1741034
+
+
+## Other news
+
+1) Matt Anderson has several blog posts on Riak and has created a Riak protobuf client in C++
+
+* Blog here ---> http://z-dev.org/thoughts/
+* Client here ---> https://github.com/andersonmat/riakcpp
+
+2) Basho head tech evangelist Mark Phillips will be speaking at Data Day Texas on Saturday March 30th, in Austin
+
+* List of speakers ---> http://datadaytexas.com/speakers
+
+3) Steve Willcock has created NodeJS tools for JSON documents in Riak
+
+* Packages here ---> https://npmjs.org/~stevewillcock
+
+4) Basho engineer Richard Shaw added to the Riak docs a list of metrics useful for monitoring purposes
+
+http://docs.basho.com/riak/latest/cookbooks/Statistics-and-Monitoring/#Riak-Metrics-To-Graph
+
+5) Dr. Margo Seltzer, Oracle architect and developer of Berkeley DB/founder of SleepyCat will keynote RICON East
+
+* RICON blog entry here ---> http://ricon.io/blog/2013-02-13-margo-seltzer-keynote.html
+
+6) Github has made available their Puppet module for Riak for new Mac workstations
+
+* Project here ---> https://github.com/boxen/puppet-riak
+
+7) Hilary Mason, Chief Scientist at Bitly, will be speaking at RICON East
+
+* RICON blog entry here ---> http://ricon.io/blog/2013-02-19-hilary-mason.html
+
+8) Basho technical evangelist Pavan Venkatesh gave a talk on Riak at Apollo Group
+
+* Slides here ---> https://speakerdeck.com/pavankv/riak-usage-at-apollo-group
+
+9) Dan Revel created notes on installing Riak under MacOS X
+
+* Blog here ---> http://nopolabs.com/2013/02/installing-riak-1-2-1-on-mac-osx-10-7/
+
+10) Andrew Nelson has created a simple Perl interface to Riak
+
+* Project here ---> https://github.com/holophrastic/data-riak
+* MetaCPAN entry by Florian Ragwitz here ---> https://metacpan.org/release/FLORA/Data-Riak-1.9/
+
+11) Alexey Gordeyev has created a multi-database ORM for NodeJS that supports several NoSQL databases, including Riak
+
+* Site here ---> http://www.camintejs.com/
+
+12) The ClojureWerkz team has release v1.4.0 of Welle, their Clojure client for Riak
+
+* Blog entry here ---> http://blog.clojurewerkz.org/blog/2013/02/21/welle-1-dot-4-0-is-released/
+
+13) Basho overachiever Tyler Hannan has created a Vagrant setup for a Riak cluster under Ubuntu
+
+* Github project here ---> https://github.com/tylerhannan/vagrant-riak-cluster
+
+14) Basho engineer Simon Vans-Colina has created a simple way to fire up a 5-node Riak cluster on a MacOS X machine
+
+* Github project here ---> https://github.com/simonvc/riak-dev-cluster
+
+15) Versu.com thanked the Erlang community for the great tools (including Riak) and support that enabled them to roll out a new iPad game
+
+* Post to erlang-questions ---> http://erlang.org/pipermail/erlang-questions/2013-February/072500.html
+
+16) Engine Yard technologist and RICON veteran Ines Sombra will talk about Riak at POSSCON
+
+* Talk description ---> http://posscon.org/presentation/getting-started-riak-cloud/
+
+17) Unison Technologies opened some of the custom tools they use with Riak
+
+* Github project ---> https://github.com/unisontech/uriak_pool
+
+18) Basho engineer Eric Redmond talked at SCALE about data management with Riak
+
+* Overview and slides ---> http://www.socallinuxexpo.org/scale11x/presentations/distributed-data-management-riak
+
+19) Hibernum uses Riak for social gaming
+
+* Basho blog post ---> http://basho.com/hibernum-selects-riak-for-user-data-storage/
+
+20) The inaugural Twin Cities Riak meetup was announced for March 5th
+
+* Meetup.com announcement ---> http://www.meetup.com/Twin-Cities-Riak-Meetup/events/106353292/
+
+21) Basho engineer Ryan Zezeski's new blog began with a discussion of the performance and behavior implications of disabling Solr's "stale check" for its connection pools
+
+* Blog post ---> http://www.zinascii.com/2013/solr-distributed-search-and-the-stale-check.html
+
+22) Various Q and A
+
+* ---> http://stackoverflow.com/questions/14991708/jackson-annotation-or-method-to-url-encode-decode-during-serialization
+* ---> http://stackoverflow.com/questions/14845506/riak-couchdb-and-mongodb-comparison-for-concurrent-inserts-not-update
+* ---> http://stackoverflow.com/questions/14854208/activity-feed-with-riak
+* ---> http://stackoverflow.com/questions/14910294/do-i-need-riak-to-run-hallway-singly
+* ---> http://stackoverflow.com/questions/14886046/riak-java-cannot-deserialize-domain-objects-from-mapreduce-query-in-scala


### PR DESCRIPTION
**Important**: before this goes live, need to make sure that the redcarpet gem is installed.

The current email format works pretty well as Markdown, just need to recognize that a single line break isn't enough to cause a line break in the rendered output (e.g., the Recap author's signature) and switching to markdown headers improves the output.

Even if old emails are just pasted into a new .md file (with the header block added) and no changes, the output should be acceptable.
